### PR TITLE
[BUILD] In favor using profile in maven command

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
           - '-Pspark-3.0'
           - '-Pspark-3.0 -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.1 -Dspark.archive.name=spark-3.1.1-bin-hadoop2.7.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.DataLakeTest'
           - '-Pspark-3.1'
-          - '-Pspark-3.1 -Dhadoop.binary.version=3.2'
+          - '-Pspark-3.1 -Pspark-hadoop-3.2'
           - '-Pspark-3.2-snapshot -pl :kyuubi-spark-sql-engine,:kyuubi-common,:kyuubi-ha,:kyuubi-zookeeper -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.DataLakeTest'
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '1.8'
-      - name: Make Distribution -Pspark-3.0
-        run: ./build/dist --tgz -Pspark-3.0
-      - name: Make Distribution -Pspark-3.0 -Dhadoop.binary.version=3.2
-        run: ./build/dist --tgz -Pspark-3.0 -Dhadoop.binary.version=3.2
-      - name: Make Distribution -Pspark-3.1
-        run: ./build/dist --tgz -Pspark-3.1
-      - name: Make Distribution -Pspark-3.1 -Dhadoop.binary.version=3.2
-        run: ./build/dist --tgz -Pspark-3.1 -Dhadoop.binary.version=3.2
+      - name: Make Distribution -Pspark-3.0 -Pspark-hadoop-2.7
+        run: ./build/dist --tgz -Pspark-3.0 -Pspark-hadoop-2.7
+      - name: Make Distribution -Pspark-3.0 -Pspark-hadoop-3.2
+        run: ./build/dist --tgz -Pspark-3.0 -Pspark-hadoop-3.2
+      - name: Make Distribution -Pspark-3.1 -Pspark-hadoop-2.7
+        run: ./build/dist --tgz -Pspark-3.1 -Pspark-hadoop-2.7
+      - name: Make Distribution -Pspark-3.1 -Pspark-hadoop-3.2
+        run: ./build/dist --tgz -Pspark-3.1 -Pspark-hadoop-3.2
       - name: Make Distribution --spark-provided
         run: ./build/dist --tgz --spark-provided
       - name: Create Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ matrix:
       env:
         - PROFILE="-Pspark-3.1"
         - EXCLUDE_TAGS="org.apache.kyuubi.tags.DataLakeTest"
-    - name: Test Kyuubi w/ -Pspark-3.1 -Dhadoop.binary.version=3.2
+    - name: Test Kyuubi w/ -Pspark-3.1 -Pspark-hadoop-3.2
       env:
-        - PROFILE="-Pspark-3.1 -Dhadoop.binary.version=3.2"
+        - PROFILE="-Pspark-3.1 -Dspark-hadoop-3.2"
         - EXCLUDE_TAGS="org.apache.kyuubi.tags.DataLakeTest"
     - name: Test Kyuubi w/ -Pspark-3.0 w/ Spark 3.1 distribution
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -1442,9 +1442,12 @@
             <id>spark-3.1</id>
             <properties>
                 <spark.version>3.1.1</spark.version>
-                <hadoop.binary.version>2.7</hadoop.binary.version>
                 <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.DataLakeTest</maven.plugin.scalatest.exclude.tags>
             </properties>
+        </profile>
+
+        <profile>
+            <id>spark-hadoop-2.7</id>
         </profile>
 
         <profile>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Recap the background of Hadoop dependencies in Kyuubi.

1. Kyuubi Server depends on few Hadoop UGI classes to support Kerbose, and those are pretty stable APIs through decade. So we decided use hadoop shaded client instead of hadoop vanilla client to avoid transitive deps, see #398.
2. Current Kyuubi build against Spark 3.0, 3.1 and 3.2-SNOTSHOT(master), all of them support and dist with both hadoop-2.7 and hadoop-3.2.

The property `hadoop.binary.version` only affect which `spark-bin-hadoop-{hadoop-version}.tgz` we will use to run integration tests in `kyuubi-main` module and include into Kyuubi binary dist bundle, and kyuubi server itself always depends on hadoop shaded client 3.2.2, thus we named the maven profile `spark-hadoop-2.7/3.2`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
