### PR TITLE
[TEST][DEP] Replace apacheds by ldapsdk for LDAP tests

### DIFF
--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-service</artifactId>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/LdapAuthenticationProviderImplSuite.scala
@@ -17,139 +17,40 @@
 
 package org.apache.kyuubi.service.authentication
 
-import java.io.File
-import javax.naming.{CommunicationException, Context}
-import javax.naming.directory.{BasicAttribute, BasicAttributes, InitialDirContext}
+import javax.naming.CommunicationException
 import javax.security.sasl.AuthenticationException
 
-import scala.collection.mutable.ArrayBuffer
+import com.unboundid.ldap.listener.InMemoryDirectoryServer
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig
 
-import org.apache.directory.api.ldap.model.name.Dn
-import org.apache.directory.api.ldap.schemaextractor.impl.DefaultSchemaLdifExtractor
-import org.apache.directory.api.ldap.schemaloader.LdifSchemaLoader
-import org.apache.directory.api.ldap.schemamanager.impl.DefaultSchemaManager
-import org.apache.directory.server.constants.ServerDNConstants
-import org.apache.directory.server.core.DefaultDirectoryService
-import org.apache.directory.server.core.api.{CacheService, InstanceLayout}
-import org.apache.directory.server.core.api.partition.Partition
-import org.apache.directory.server.core.api.schema.SchemaPartition
-import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition
-import org.apache.directory.server.core.partition.ldif.LdifPartition
-import org.apache.directory.server.ldap.LdapServer
-import org.apache.directory.server.protocol.shared.transport.TcpTransport
-import org.apache.mina.util.AvailablePortFinder
-
-import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 
 class LdapAuthenticationProviderImplSuite extends KyuubiFunSuite {
 
-  private val servicePort = AvailablePortFinder.getNextAvailable(9000)
-  private val service = new DefaultDirectoryService
-  private val workingDIr = Utils.createTempDir().toFile
-  private val ldapServer: LdapServer = new LdapServer()
-
-  private val partitions = ArrayBuffer[Partition]()
+  private var ldapServer: InMemoryDirectoryServer = _
 
   private val conf = new KyuubiConf()
 
   override def beforeAll(): Unit = {
-    service.setInstanceLayout(new InstanceLayout(workingDIr))
-    val cachedService = new CacheService()
-    cachedService.initialize(service.getInstanceLayout)
-    service.setCacheService(cachedService)
+    val config = new InMemoryDirectoryServerConfig("ou=users")
+    config.addAdditionalBindCredentials("uid=kentyao,ou=users", "kentyao")
+    ldapServer = new InMemoryDirectoryServer(config)
+    ldapServer.startListening()
 
-    val schemaPartitionDir = new File(service.getInstanceLayout.getPartitionsDirectory, "schema")
-    if (!schemaPartitionDir.exists()) {
-      val extractor = new DefaultSchemaLdifExtractor(
-        service.getInstanceLayout.getPartitionsDirectory)
-      extractor.extractOrCopy()
-    }
-
-    val loader = new LdifSchemaLoader(schemaPartitionDir)
-    val schemaManager = new DefaultSchemaManager(loader)
-    schemaManager.loadAllEnabled()
-    service.setSchemaManager(schemaManager)
-
-    val schemaLDifPartition = new LdifPartition(schemaManager)
-    schemaLDifPartition.setPartitionPath(schemaPartitionDir.toURI)
-    val schemaPartition = new SchemaPartition(schemaManager)
-    schemaPartition.setWrappedPartition(schemaLDifPartition)
-    service.setSchemaPartition(schemaPartition)
-
-    val jdbmPartition = new JdbmPartition(service.getSchemaManager)
-    jdbmPartition.setId("kyuubi")
-    jdbmPartition.setPartitionPath(
-      new File(service.getInstanceLayout.getPartitionsDirectory, jdbmPartition.getId).toURI)
-    jdbmPartition.setSuffixDn(new Dn(ServerDNConstants.SYSTEM_DN))
-    jdbmPartition.setSchemaManager(service.getSchemaManager)
-    service.setSystemPartition(jdbmPartition)
-
-    service.getChangeLog.setEnabled(false)
-
-    service.setDenormalizeOpAttrsEnabled(true)
-
-    service.startup()
-    ldapServer.setDirectoryService(service)
-    ldapServer.setTransports(new TcpTransport(servicePort))
-    ldapServer.start()
-
-    conf.set(AUTHENTICATION_LDAP_URL, "ldap://localhost:" + ldapServer.getPort)
-
-    addPartition("kentyao", "uid=kentyao,ou=users")
-    addUser()
+    conf.set(AUTHENTICATION_LDAP_URL, s"ldap://localhost:" + ldapServer.getListenPort)
 
     super.beforeAll()
   }
 
-  private def addUser(): Unit = {
-    val env = new java.util.Hashtable[String, Any]()
-    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
-    env.put(Context.SECURITY_AUTHENTICATION, "simple")
-    env.put(Context.PROVIDER_URL, conf.get(AUTHENTICATION_LDAP_URL).get)
-    env.put(Context.SECURITY_PRINCIPAL, "uid=admin,ou=system")
-    env.put(Context.SECURITY_CREDENTIALS, "secret")
-
-    val container = new BasicAttributes()
-    val objClasses = new BasicAttribute("objectClass")
-    objClasses.add("inetOrgPerson")
-    val cn = new BasicAttribute("cn", "kentyao")
-    val o = new BasicAttribute("o", "kyuubi")
-    val sn = new BasicAttribute("sn", "yao")
-    val uid = new BasicAttribute("uid", "kentyao")
-    val password = new BasicAttribute("userpassword", "kentyao")
-    container.put(objClasses)
-    container.put(cn)
-    container.put(uid)
-    container.put(o)
-    container.put(sn)
-    container.put(password)
-    val context = new InitialDirContext(env)
-    context.createSubcontext("uid=kentyao,ou=users", container)
-  }
-
-  private def addPartition(id: String, dn: String): Partition = {
-    val partition = new JdbmPartition(service.getSchemaManager)
-    partition.setId(id)
-    partition.setPartitionPath(
-      new File(service.getInstanceLayout.getPartitionsDirectory, partition.getId).toURI)
-    partition.setSuffixDn(new Dn(dn))
-    service.addPartition(partition)
-    partitions += partition
-    partition
-  }
-
   override def afterAll(): Unit = {
-    if (ldapServer.isStarted) {
-      ldapServer.stop()
-    }
+    ldapServer.close()
     super.afterAll()
   }
 
   test("ldap server is started") {
-    assert(ldapServer.isStarted)
-    assert(ldapServer.getPort > 0)
+    assert(ldapServer.getListenPort > 0)
   }
 
   test("authenticate tests") {

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -87,6 +87,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-zookeeper</artifactId>
             <version>${project.version}</version>

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -87,18 +87,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minikdc</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-service</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-zookeeper</artifactId>
             <version>${project.version}</version>

--- a/kyuubi-ha/pom.xml
+++ b/kyuubi-ha/pom.xml
@@ -62,6 +62,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-zookeeper</artifactId>
             <version>${project.version}</version>

--- a/kyuubi-ha/pom.xml
+++ b/kyuubi-ha/pom.xml
@@ -62,18 +62,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minikdc</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-service</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.kyuubi</groupId>
             <artifactId>kyuubi-zookeeper</artifactId>
             <version>${project.version}</version>

--- a/kyuubi-main/pom.xml
+++ b/kyuubi-main/pom.xml
@@ -116,18 +116,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minikdc</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-service</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>

--- a/kyuubi-main/pom.xml
+++ b/kyuubi-main/pom.xml
@@ -116,12 +116,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minikdc</artifactId>
             <scope>test</scope>
@@ -130,6 +124,12 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/kyuubi-main/pom.xml
+++ b/kyuubi-main/pom.xml
@@ -122,6 +122,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>${iceberg.name}</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
 
-        <apacheds.version>2.0.0-M15</apacheds.version>
         <codahale.metrics.version>4.1.1</codahale.metrics.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -73,6 +72,7 @@
         <hadoop.binary.version>2.7</hadoop.binary.version>
         <hive.version>2.3.7</hive.version>
         <jackson.version>2.11.4</jackson.version>
+        <ldapsdk.version>5.1.4</ldapsdk.version>
         <spark.version>3.0.2</spark.version>
         <spark.archive.name>spark-${spark.version}-bin-hadoop${hadoop.binary.version}.tgz</spark.archive.name>
         <spark.archive.mirror>https://archive.apache.org/dist/spark/spark-${spark.version}</spark.archive.mirror>
@@ -998,14 +998,6 @@
                 <version>${hadoop.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.apache.directory.server</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.directory.api</groupId>
-                        <artifactId>api-all</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
@@ -1017,15 +1009,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-service</artifactId>
-                <version>${apacheds.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>com.unboundid</groupId>
+                <artifactId>unboundid-ldapsdk</artifactId>
+                <version>${ldapsdk.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
TL;DR The UnboundID LDAP SDK for Java has much friendly API and zero dependencies.
https://ldap.com/unboundid-ldap-sdk-for-java/

Apache Directory Service vs UnboundID LDAP SDK 
1. Apache Directory Service is quite heavy stuff compare to our requirement, we just need a embedded LDAP server for UT.
2. The API of Apache Directory Service and Java Naming are not straightforward, because it's not specifically designed for LDAP.
3. Apache Directory Service provided a single fat-jar contains dependencies which aren't relocated.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

> The UnboundID LDAP SDK for Java is free to use and redistribute in open source or proprietary applications under the terms of the Apache License, Version 2 (or, for legacy purposes, the GPLv2, the LGPLv2.1, or the UnboundID LDAP SDK Free Use License).

According to https://opensource.stackexchange.com/questions/2115/if-something-is-licensed-to-me-under-two-open-source-licences-can-i-redistrib?rq=1, we can pick up one of the licenses declared by the library, not all of them.