### PR TITLE
[BUILD] Add build timestamp and support scala.binary.version specific code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <jars.target.dir>${project.build.directory}/scala-${scala.binary.version}/jars</jars.target.dir>
 
         <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
+        <maven.plugin.build.helper>3.2.0</maven.plugin.build.helper>
         <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
         <!-- DO NOT bump 4.4.0, see https://github.com/NetEase/kyuubi/pull/441 -->
         <maven.plugin.scala.version>4.3.0</maven.plugin.scala.version>
@@ -105,6 +106,10 @@
         <maven.plugin.download.version>1.6.0</maven.plugin.download.version>
         <maven.plugin.silencer.version>1.6.0</maven.plugin.silencer.version>
         <maven.plugin.rat.version>0.13</maven.plugin.rat.version>
+
+        <!-- Needed for consistent times -->
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss z</maven.build.timestamp.format>
+
         <!-- Package to use when relocating shaded classes. -->
         <kyuubi.shade.packageName>org.apache.kyuubi.shade</kyuubi.shade.packageName>
     </properties>
@@ -1054,6 +1059,52 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${maven.plugin.antrun.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${maven.plugin.build.helper}</version>
+                    <executions>
+                        <execution>
+                            <id>module-timestamp-property</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>timestamp-property</goal>
+                            </goals>
+                            <configuration>
+                                <name>module.build.timestamp</name>
+                                <pattern>${maven.build.timestamp.format}</pattern>
+                                <timeSource>current</timeSource>
+                                <timeZone>Asia/Shanghai</timeZone>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>local-timestamp-property</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>timestamp-property</goal>
+                            </goals>
+                            <configuration>
+                                <name>local.build.timestamp</name>
+                                <pattern>${maven.build.timestamp.format}</pattern>
+                                <timeSource>build</timeSource>
+                                <timeZone>Asia/Shanghai</timeZone>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add-scala-sources</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>src/main/scala-${scala.binary.version}</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1404,6 +1404,11 @@
             </plugin>
 
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <jars.target.dir>${project.build.directory}/scala-${scala.binary.version}/jars</jars.target.dir>
 
         <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
-        <maven.plugin.build.helper>3.2.0</maven.plugin.build.helper>
+        <maven.plugin.build.helper.version>3.2.0</maven.plugin.build.helper.version>
         <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
         <!-- DO NOT bump 4.4.0, see https://github.com/NetEase/kyuubi/pull/441 -->
         <maven.plugin.scala.version>4.3.0</maven.plugin.scala.version>
@@ -1064,7 +1064,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>${maven.plugin.build.helper}</version>
+                    <version>${maven.plugin.build.helper.version}</version>
                     <executions>
                         <execution>
                             <id>module-timestamp-property</id>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This change added `module.build.timestamp` and `local.build.timestamp` to maven properties, so we can use it in later for make dist.

This change also add `src/main/scala-${scala.binary.version}` to maven sources files, so we can write `scala.binary.version` specific code to the codebase.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
