### PR TITLE
[KYUUBI #544] Add UT for engine deregister exception and refactor package name for SparkSQLEngineListenerSuite

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
@@ -59,8 +59,8 @@ class SparkSQLEngineListener(server: Serverable) extends SparkListener with Logg
        }
 
        deregisterInfo.foreach { info =>
-         error(info, e)
          server.discoveryService.asInstanceOf[EngineServiceDiscovery].stop()
+         error(info, e)
        }
 
      case _ =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
@@ -68,7 +68,7 @@ class SparkSQLEngineListener(server: Serverable) extends SparkListener with Logg
        }
 
        deregisterInfo.foreach { info =>
-         error(info, e)
+         error(info, ve)
          server.discoveryService.asInstanceOf[EngineServiceDiscovery].stop()
        }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
@@ -51,7 +51,6 @@ class SparkSQLEngineListener(server: Serverable) extends SparkListener with Logg
    jobEnd.jobResult match {
      case JobFailed(e) if e != null =>
        val cause = findCause(e)
-
        var deregisterInfo: Option[String] = None
        if (deregisterExceptions.exists(_.equals(cause.getClass.getCanonicalName))) {
          deregisterInfo = Some("Job failed exception class is in the set of " +

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
@@ -18,6 +18,10 @@
 // Some object likes `JobFailed` is only accessible in org.apache.spark package
 package org.apache.spark.kyuubi
 
+import java.lang.reflect.{InvocationTargetException, UndeclaredThrowableException}
+
+import scala.annotation.tailrec
+
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerApplicationEnd, SparkListenerJobEnd}
 
@@ -46,33 +50,35 @@ class SparkSQLEngineListener(server: Serverable) extends SparkListener with Logg
   override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
    jobEnd.jobResult match {
      case JobFailed(e) if e != null =>
-       // get valuable exception
-       val ve = e match {
-         case se: SparkException if se.getCause != null =>
-           se.getCause
-         case _ => e
-       }
+       val cause = findCause(e)
 
        var deregisterInfo: Option[String] = None
-       if (deregisterExceptions.exists(_.equals(ve.getClass.getCanonicalName))) {
+       if (deregisterExceptions.exists(_.equals(cause.getClass.getCanonicalName))) {
          deregisterInfo = Some("Job failed exception class is in the set of " +
            s"${ENGINE_DEREGISTER_EXCEPTION_CLASSES.key}, deregistering the engine.")
-       } else if (ve.getMessage != null &&
-         deregisterMessages.exists(ve.getMessage.contains)) {
+       } else if (cause.getMessage != null &&
+         deregisterMessages.exists(cause.getMessage.contains)) {
          deregisterInfo = Some("Job failed exception message matches the specified " +
            s"${ENGINE_DEREGISTER_EXCEPTION_MESSAGES.key}, deregistering the engine.")
-       } else if (ve.getStackTrace != null &&
-         deregisterStacktraces.exists(ve.getStackTrace.mkString("\n").contains)) {
+       } else if (cause.getStackTrace != null &&
+         deregisterStacktraces.exists(cause.getStackTrace.mkString("\n").contains)) {
          deregisterInfo = Some("Job failed exception stacktrace matches the specified " +
            s"${ENGINE_DEREGISTER_EXCEPTION_STACKTRACES.key}, deregistering the engine.")
        }
 
        deregisterInfo.foreach { info =>
-         error(info, ve)
+         error(info, cause)
          server.discoveryService.asInstanceOf[EngineServiceDiscovery].stop()
        }
 
      case _ =>
    }
+  }
+
+  @tailrec
+  private def findCause(t: Throwable): Throwable = t match {
+    case e @ (_: SparkException | _: UndeclaredThrowableException | _: InvocationTargetException)
+      if e.getCause != null => findCause(e.getCause)
+    case e => e
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -21,12 +21,13 @@ import java.util.UUID
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.internal.SQLConf.{ANSI_ENABLED, DECIMAL_OPERATIONS_ALLOW_PREC_LOSS}
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.engine.spark.WithDiscoverySparkSQLEngine
 import org.apache.kyuubi.service.ServiceState
 
-abstract class SparkSQLEngineDeregisterSuite extends WithDiscoverySparkSQLEngine{
+abstract class SparkSQLEngineDeregisterSuite extends WithDiscoverySparkSQLEngine {
   override def withKyuubiConf: Map[String, String] = {
     super.withKyuubiConf ++ Map(
       ANSI_ENABLED.key -> "true",
@@ -42,7 +43,9 @@ abstract class SparkSQLEngineDeregisterSuite extends WithDiscoverySparkSQLEngine
       "CAST(col3 AS DECIMAL(22,18)) from t"
     assert(engine.discoveryService.getServiceState === ServiceState.STARTED)
     intercept[SparkException](spark.sql(query).collect())
-    assert(engine.discoveryService.getServiceState === ServiceState.STOPPED)
+    eventually(timeout(5.seconds), interval(1.second)) {
+      assert(engine.discoveryService.getServiceState === ServiceState.STOPPED)
+    }
   }
 }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.kyuubi
+
+import java.util.UUID
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.internal.SQLConf.{ANSI_ENABLED, DECIMAL_OPERATIONS_ALLOW_PREC_LOSS}
+
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.engine.spark.WithDiscoverySparkSQLEngine
+import org.apache.kyuubi.service.ServiceState
+
+abstract class SparkSQLEngineDeregisterSuite extends WithDiscoverySparkSQLEngine{
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ Map(
+      ANSI_ENABLED.key -> "true",
+      DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key -> "false"
+    )
+  }
+
+  override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID().toString}"
+
+  test("deregister when meeting specified exception") {
+    spark.sql("CREATE TABLE t AS SELECT * FROM VALUES(-499.198741, 1, 1)")
+    val query = "SELECT CAST(col1 AS DECIMAL(18,6)) / CAST(col2 AS DECIMAL(18,14)) * " +
+      "CAST(col3 AS DECIMAL(22,18)) from t"
+    assert(engine.discoveryService.getServiceState === ServiceState.STARTED)
+    intercept[SparkException](spark.sql(query).collect())
+    assert(engine.discoveryService.getServiceState === ServiceState.STOPPED)
+  }
+}
+
+class SparkSQLEngineDeregisterExceptionSuite extends SparkSQLEngineDeregisterSuite {
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_CLASSES.key ->
+      classOf[SparkException].getCanonicalName)
+  }
+}
+
+class SparkSQLEngineDeregisterMsgSuite extends SparkSQLEngineDeregisterSuite {
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_MESSAGES.key ->
+      classOf[ArithmeticException].getCanonicalName)
+  }
+}
+
+class SparkSQLEngineDeregisterStacktraceSuite extends SparkSQLEngineDeregisterSuite {
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_STACKTRACES.key ->
+      "org.apache.spark.scheduler.DAGScheduler.abortStage")
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineListenerSuite.scala
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.engine.spark
+package org.apache.spark.kyuubi
 
+import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
 import org.apache.kyuubi.service.ServiceState
 
 class SparkSQLEngineListenerSuite extends WithSparkSQLEngine {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Add UT for engine deregister exception

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
