### PR TITLE
Forbid set env:* in thrift connection configurations

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -654,6 +654,21 @@ class SparkOperationSuite extends WithSparkSQLEngine with JDBCTests {
     }
   }
 
+  test("env:* variables can not be set") {
+    withThriftClient { client =>
+      val req = new TOpenSessionReq()
+      req.setUsername("chengpan")
+      req.setPassword("123")
+      val conf = Map(
+        "env:ABC" -> "xyz")
+      req.setConfiguration(conf.asJava)
+      val tOpenSessionResp = client.OpenSession(req)
+      val status = tOpenSessionResp.getStatus
+      assert(status.getStatusCode === TStatusCode.ERROR_STATUS)
+      assert(status.getErrorMessage contains s"env:* variables can not be set")
+    }
+  }
+
   test("test variable substitution") {
     withThriftClient { client =>
       val req = new TOpenSessionReq()

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -660,7 +660,7 @@ class SparkOperationSuite extends WithSparkSQLEngine with JDBCTests {
       req.setUsername("chengpan")
       req.setPassword("123")
       val conf = Map(
-        "env:ABC" -> "xyz")
+        "set:env:ABC" -> "xyz")
       req.setConfiguration(conf.asJava)
       val tOpenSessionResp = client.OpenSession(req)
       val status = tOpenSessionResp.getStatus

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -102,6 +102,10 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
 
   // strip prefix and validate whether if key is restricted, ignored or valid
   def validateKey(key: String, value: String): Option[(String, String)] = {
+    if (key.startsWith(ENV_PREFIX)) {
+      throw KyuubiSQLException(s"$key is forbidden, env:* variables can not be set.")
+    }
+
     val normalizedKey = if (key.startsWith(SET_PREFIX)) {
       val newKey = key.substring(SET_PREFIX.length)
       if (newKey.startsWith(SYSTEM_PREFIX)) {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -102,13 +102,11 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
 
   // strip prefix and validate whether if key is restricted, ignored or valid
   def validateKey(key: String, value: String): Option[(String, String)] = {
-    if (key.startsWith(ENV_PREFIX)) {
-      throw KyuubiSQLException(s"$key is forbidden, env:* variables can not be set.")
-    }
-
     val normalizedKey = if (key.startsWith(SET_PREFIX)) {
       val newKey = key.substring(SET_PREFIX.length)
-      if (newKey.startsWith(SYSTEM_PREFIX)) {
+      if (newKey.startsWith(ENV_PREFIX)) {
+        throw KyuubiSQLException(s"$key is forbidden, env:* variables can not be set.")
+      } else if (newKey.startsWith(SYSTEM_PREFIX)) {
         newKey.substring(SYSTEM_PREFIX.length)
       } else if (newKey.startsWith(HIVECONF_PREFIX)) {
         newKey.substring(HIVECONF_PREFIX.length)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change only forbid the `set:env:*` from thrift connection configurations, to match hive behavior, forbid `set env:*` in SQL, we need to change it in Spark.
#508
https://issues.apache.org/jira/browse/HIVE-6175

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
