### PR TITLE
Improve OperationLog to deliver detail stats of sql statements

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.kyuubi
+
+import java.util.Properties
+
+import org.apache.spark.SparkContext.SPARK_JOB_GROUP_ID
+import org.apache.spark.scheduler._
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.operation.Operation
+import org.apache.kyuubi.operation.log.OperationLog
+
+/**
+ * A [[SparkListener]] based on spark's DeveloperApi [[StatsReportListener]], used to appending
+ * statement/operation level logs to the OperationLog which belong to the same `spark.jobGroup.id`
+ *
+ * @param operation the corresponding operation
+ */
+class SQLOperationListener(operation: Operation) extends StatsReportListener with Logging {
+
+  private val operationId: String = operation.getHandle.identifier.toString
+  private val activeJobs = new java.util.HashSet[Int]()
+  private val activeStages = new java.util.HashSet[Int]()
+
+  // For broadcast, Spark will introduce a new runId as SPARK_JOB_GROUP_ID, see:
+  // https://github.com/apache/spark/pull/24595, So we will miss these logs.
+  // TODO: Fix this until the below ticket resolved
+  // https://issues.apache.org/jira/browse/SPARK-34064
+  private def sameGroupId(properties: Properties): Boolean = {
+    properties != null && properties.getProperty(SPARK_JOB_GROUP_ID) == operationId
+  }
+
+  private def withOperationLog(f : => Unit): Unit = {
+    try {
+      operation.getOperationLog.foreach(OperationLog.setCurrentOperationLog)
+      f
+    } finally {
+      OperationLog.removeCurrentOperationLog()
+    }
+  }
+
+  override def onJobStart(jobStart: SparkListenerJobStart): Unit = activeJobs.synchronized {
+    if (sameGroupId(jobStart.properties)) {
+      val jobId = jobStart.jobId
+      val stageSize = jobStart.stageInfos.size
+      withOperationLog {
+        activeJobs.add(jobId)
+        info(s"Query [$operationId]: Job $jobId started with $stageSize stages," +
+          s" ${activeJobs.size()} active jobs running")
+      }
+    }
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = activeJobs.synchronized {
+    val jobId = jobEnd.jobId
+    if (activeJobs.remove(jobId)) {
+      val hint = jobEnd.jobResult match {
+        case JobSucceeded => "succeeded"
+        case _ => "failed" // TODO: Handle JobFailed(exception: Exception)
+      }
+      withOperationLog {
+        info(s"Query [$operationId]: Job $jobId $hint, ${activeJobs.size()} active jobs running")
+      }
+    }
+  }
+
+  override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
+    activeStages.synchronized {
+      if (sameGroupId(stageSubmitted.properties)) {
+        val stageInfo = stageSubmitted.stageInfo
+        val stageId = stageInfo.stageId
+        activeStages.add(stageId)
+        withOperationLog {
+          info(s"Query [$operationId]: Stage $stageId started with ${stageInfo.numTasks} tasks," +
+            s" ${activeStages.size()} active stages running")
+        }
+      }
+    }
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+    val stageInfo = stageCompleted.stageInfo
+    val stageId = stageInfo.stageId
+    activeStages.synchronized {
+      if (activeStages.remove(stageId)) {
+        withOperationLog(super.onStageCompleted(stageCompleted))
+      }
+    }
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = activeStages.synchronized {
+    if (activeStages.contains(taskEnd.stageId)) super.onTaskEnd(taskEnd)
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkSQLEngineListener.scala
@@ -32,14 +32,23 @@ import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.ha.client.EngineServiceDiscovery
 import org.apache.kyuubi.service.{Serverable, ServiceState}
 
+/**
+ * A [[SparkListener]] for engine level events handling
+ *
+ * @param server the corresponding engine
+ */
 class SparkSQLEngineListener(server: Serverable) extends SparkListener with Logging {
   import KyuubiSQLException.stringifyException
 
   // the conf of server is null before initialized, use lazy val here
-  lazy val deregisterExceptions = server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_CLASSES)
-  lazy val deregisterMessages = server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_MESSAGES)
-  lazy val deregisterExceptionTTL = server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_TTL)
-  lazy val jobMaxFailures = server.getConf.get(ENGINE_DEREGISTER_JOB_MAX_FAILURES)
+  private lazy val deregisterExceptions: Seq[String] =
+    server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_CLASSES)
+  private lazy val deregisterMessages: Seq[String] =
+    server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_MESSAGES)
+  private lazy val deregisterExceptionTTL: Long =
+    server.getConf.get(ENGINE_DEREGISTER_EXCEPTION_TTL)
+  private lazy val jobMaxFailures: Int =
+    server.getConf.get(ENGINE_DEREGISTER_JOB_MAX_FAILURES)
 
   private val jobFailureNum = new AtomicInteger(0)
   @volatile private var lastFailureTime: Long = 0

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.kyuubi
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchOrientation, TFetchResultsReq}
+import org.scalatest.time.SpanSugar._
+
+import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
+import org.apache.kyuubi.operation.JDBCTestUtils
+
+class SQLOperationListenerSuite extends WithSparkSQLEngine with JDBCTestUtils {
+
+  override def withKyuubiConf: Map[String, String] = Map.empty
+
+  override protected def jdbcUrl: String = getJdbcUrl
+
+  test("operation listener") {
+    val sql = "select  /*+ REPARTITION(3, a) */  a  from values(1) t(a);"
+    withSessionHandle { (client, handle) =>
+      val req = new TExecuteStatementReq()
+      req.setSessionHandle(handle)
+      req.setStatement(sql)
+      val tExecuteStatementResp = client.ExecuteStatement(req)
+      val opHandle = tExecuteStatementResp.getOperationHandle
+      val fetchResultsReq = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, 1000)
+      fetchResultsReq.setFetchType(1.toShort)
+      eventually(timeout(90.seconds), interval(500.milliseconds)) {
+        val resultsResp = client.FetchResults(fetchResultsReq)
+        val toSeq = resultsResp.getResults.getColumns.get(0).getStringVal.getValues.asScala.toSeq
+        assert(toSeq.exists(_.contains("Job 0 started with 2 stages")))
+        assert(toSeq.exists(_.contains("Stage 0 started with 1 tasks")))
+        assert(toSeq.exists(_.contains("Stage 1 started with 3 tasks")))
+        assert(toSeq.exists(_.contains("Finished stage:")))
+        assert(toSeq.exists(_.contains("Job 0 succeeded")))
+      }
+    }
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
@@ -32,7 +32,7 @@ class SQLOperationListenerSuite extends WithSparkSQLEngine with JDBCTestUtils {
   override protected def jdbcUrl: String = getJdbcUrl
 
   test("operation listener") {
-    val sql = "select  /*+ REPARTITION(3, a) */  a  from values(1) t(a);"
+    val sql = "select /*+ REPARTITION(3, a) */ a from values(1) t(a);"
     withSessionHandle { (client, handle) =>
       val req = new TExecuteStatementReq()
       req.setSessionHandle(handle)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SQLOperationListenerSuite.scala
@@ -44,9 +44,9 @@ class SQLOperationListenerSuite extends WithSparkSQLEngine with JDBCTestUtils {
       eventually(timeout(90.seconds), interval(500.milliseconds)) {
         val resultsResp = client.FetchResults(fetchResultsReq)
         val toSeq = resultsResp.getResults.getColumns.get(0).getStringVal.getValues.asScala.toSeq
-        assert(toSeq.exists(_.contains("Job 0 started with 2 stages")))
-        assert(toSeq.exists(_.contains("Stage 0 started with 1 tasks")))
-        assert(toSeq.exists(_.contains("Stage 1 started with 3 tasks")))
+        assert(toSeq.exists(_.contains("started with 2 stages")))
+        assert(toSeq.exists(_.contains("started with 1 tasks")))
+        assert(toSeq.exists(_.contains("started with 3 tasks")))
         assert(toSeq.exists(_.contains("Finished stage:")))
         assert(toSeq.exists(_.contains("Job 0 succeeded")))
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`OperationLog` is used to divert SQL statement-specific logs to a temporary local file at the engine side and to be fetched to the client-side(e.g. beeline). It is an InheritableThreadLocal variable in which thread the `SparkSession` instance lays. Inside Spark, there are a lot of threads created via the java `Executors`, for which the `OperationLog` cannot be inherited, so the client-side lacks information on how their jobs are running. This is not user-friendly especially for queries that contain a lot of jobs.


In this PR, we add a new SparkListener for SQL operation which diverts the SQL statement-specific logs by `spark.jobGroup.id`. The listener will dump Job/Stage and Task summaries to the `OperationLog`

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

```logtalk
2021-05-08 10:25:54.301 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Job 3 started with 4 stages, 1 active jobs running
2021-05-08 10:25:54.303 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Stage 6 started with 5 tasks, 1 active stages running
2021-05-08 10:25:54.347 INFO kyuubi.SQLOperationListener: Finished stage: Stage(6, 0); Name: 'collect at ExecuteStatement.scala:82'; Status: succeeded; numTasks: 5; Took: 44 msec
2021-05-08 10:25:54.347 INFO scheduler.StatsReportListener: task runtime:(count: 5, mean: 36.400000, stdev: 1.019804, max: 38.000000, min: 35.000000)
2021-05-08 10:25:54.347 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.347 INFO scheduler.StatsReportListener: 	35.0 ms	35.0 ms	35.0 ms	36.0 ms	36.0 ms	37.0 ms	38.0 ms	38.0 ms	38.0 ms
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: shuffle bytes written:(count: 5, mean: 59.000000, stdev: 0.000000, max: 59.000000, min: 59.000000)
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: 	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: fetch wait time:(count: 5, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.348 INFO scheduler.StatsReportListener: 	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: remote bytes read:(count: 5, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: task result size:(count: 5, mean: 1965.000000, stdev: 0.000000, max: 1965.000000, min: 1965.000000)
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	1965.0 B	1965.0 B	1965.0 B	1965.0 B	1965.0 B	1965.0 B	1965.0 B	1965.0 B	1965.0 B
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: executor (non-fetch) time pct: (count: 5, mean: 82.948068, stdev: 1.278517, max: 84.210526, min: 80.555556)
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.349 INFO scheduler.StatsReportListener: 	81 %	81 %	81 %	83 %	83 %	84 %	84 %	84 %	84 %
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: fetch wait time pct: (count: 5, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: 	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: other time pct: (count: 5, mean: 17.051932, stdev: 1.278517, max: 19.444444, min: 15.789474)
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.350 INFO scheduler.StatsReportListener: 	16 %	16 %	16 %	16 %	17 %	17 %	19 %	19 %	19 %
2021-05-08 10:25:54.357 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Stage 7 started with 300 tasks, 1 active stages running
2021-05-08 10:25:54.644 INFO kyuubi.SQLOperationListener: Finished stage: Stage(7, 0); Name: 'collect at ExecuteStatement.scala:82'; Status: succeeded; numTasks: 300; Took: 287 msec
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: task runtime:(count: 300, mean: 15.203333, stdev: 9.396559, max: 45.000000, min: 4.000000)
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: 	4.0 ms	5.0 ms	6.0 ms	8.0 ms	13.0 ms	18.0 ms	31.0 ms	38.0 ms	45.0 ms
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: shuffle bytes written:(count: 300, mean: 56.030000, stdev: 0.298496, max: 59.000000, min: 56.000000)
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.645 INFO scheduler.StatsReportListener: 	56.0 B	56.0 B	56.0 B	56.0 B	56.0 B	56.0 B	56.0 B	56.0 B	59.0 B
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: fetch wait time:(count: 300, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: 	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: remote bytes read:(count: 300, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.646 INFO scheduler.StatsReportListener: 	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B
2021-05-08 10:25:54.647 INFO scheduler.StatsReportListener: task result size:(count: 300, mean: 2865.150000, stdev: 9.371633, max: 2906.000000, min: 2863.000000)
2021-05-08 10:25:54.647 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.647 INFO scheduler.StatsReportListener: 	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB	2.8 KiB
2021-05-08 10:25:54.648 INFO scheduler.StatsReportListener: executor (non-fetch) time pct: (count: 300, mean: 66.577940, stdev: 18.397778, max: 95.121951, min: 10.526316)
2021-05-08 10:25:54.648 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.648 INFO scheduler.StatsReportListener: 	11 %	33 %	40 %	56 %	71 %	81 %	87 %	88 %	95 %
2021-05-08 10:25:54.649 INFO scheduler.StatsReportListener: fetch wait time pct: (count: 300, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.649 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.649 INFO scheduler.StatsReportListener: 	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %
2021-05-08 10:25:54.650 INFO scheduler.StatsReportListener: other time pct: (count: 300, mean: 33.422060, stdev: 18.397778, max: 89.473684, min: 4.878049)
2021-05-08 10:25:54.650 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.650 INFO scheduler.StatsReportListener: 	 5 %	12 %	13 %	19 %	29 %	44 %	60 %	67 %	89 %
2021-05-08 10:25:54.650 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Stage 8 started with 1 tasks, 1 active stages running
2021-05-08 10:25:54.733 INFO kyuubi.SQLOperationListener: Finished stage: Stage(8, 0); Name: 'collect at ExecuteStatement.scala:82'; Status: succeeded; numTasks: 1; Took: 87 msec
2021-05-08 10:25:54.733 INFO scheduler.StatsReportListener: task runtime:(count: 1, mean: 81.000000, stdev: 0.000000, max: 81.000000, min: 81.000000)
2021-05-08 10:25:54.733 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.733 INFO scheduler.StatsReportListener: 	81.0 ms	81.0 ms	81.0 ms	81.0 ms	81.0 ms	81.0 ms	81.0 ms	81.0 ms	81.0 ms
2021-05-08 10:25:54.734 INFO scheduler.StatsReportListener: shuffle bytes written:(count: 1, mean: 59.000000, stdev: 0.000000, max: 59.000000, min: 59.000000)
2021-05-08 10:25:54.734 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.734 INFO scheduler.StatsReportListener: 	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B	59.0 B
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: fetch wait time:(count: 1, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: remote bytes read:(count: 1, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: task result size:(count: 1, mean: 3065.000000, stdev: 0.000000, max: 3065.000000, min: 3065.000000)
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB	3.0 KiB
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: executor (non-fetch) time pct: (count: 1, mean: 95.061728, stdev: 0.000000, max: 95.061728, min: 95.061728)
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.735 INFO scheduler.StatsReportListener: 	95 %	95 %	95 %	95 %	95 %	95 %	95 %	95 %	95 %
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: fetch wait time pct: (count: 1, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: 	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: other time pct: (count: 1, mean: 4.938272, stdev: 0.000000, max: 4.938272, min: 4.938272)
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.736 INFO scheduler.StatsReportListener: 	 5 %	 5 %	 5 %	 5 %	 5 %	 5 %	 5 %	 5 %	 5 %
2021-05-08 10:25:54.739 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Stage 9 started with 200 tasks, 1 active stages running
2021-05-08 10:25:54.844 INFO kyuubi.SQLOperationListener: Finished stage: Stage(9, 0); Name: 'collect at ExecuteStatement.scala:82'; Status: succeeded; numTasks: 200; Took: 105 msec
2021-05-08 10:25:54.845 INFO scheduler.DAGScheduler: Job 3 finished: collect at ExecuteStatement.scala:82, took 0.547547 s
2021-05-08 10:25:54.845 INFO scheduler.StatsReportListener: task runtime:(count: 200, mean: 15.100000, stdev: 11.464729, max: 48.000000, min: 4.000000)
2021-05-08 10:25:54.845 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.845 INFO scheduler.StatsReportListener: 	4.0 ms	6.0 ms	7.0 ms	8.0 ms	10.0 ms	16.0 ms	40.0 ms	43.0 ms	48.0 ms
2021-05-08 10:25:54.845 INFO scheduler.StatsReportListener: shuffle bytes written:(count: 200, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: fetch wait time:(count: 200, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms	0.0 ms
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: remote bytes read:(count: 200, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.846 INFO scheduler.StatsReportListener: 	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B	0.0 B
2021-05-08 10:25:54.847 INFO scheduler.StatsReportListener: task result size:(count: 200, mean: 2326.135000, stdev: 26.673897, max: 2414.000000, min: 2311.000000)
2021-05-08 10:25:54.847 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.847 INFO scheduler.StatsReportListener: 	2.3 KiB	2.3 KiB	2.3 KiB	2.3 KiB	2.3 KiB	2.3 KiB	2.3 KiB	2.3 KiB	2.4 KiB
2021-05-08 10:25:54.847 INFO scheduler.StatsReportListener: executor (non-fetch) time pct: (count: 200, mean: 2.971561, stdev: 8.036931, max: 47.727273, min: 0.000000)
2021-05-08 10:25:54.847 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: 	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	10 %	18 %	48 %
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: fetch wait time pct: (count: 200, mean: 0.000000, stdev: 0.000000, max: 0.000000, min: 0.000000)
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: 	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %	 0 %
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: other time pct: (count: 200, mean: 97.028439, stdev: 8.036931, max: 100.000000, min: 52.272727)
2021-05-08 10:25:54.848 INFO scheduler.StatsReportListener: 	0%	5%	10%	25%	50%	75%	90%	95%	100%
2021-05-08 10:25:54.849 INFO scheduler.StatsReportListener: 	52 %	82 %	90 %	100 %	100 %	100 %	100 %	100 %	100 %
2021-05-08 10:25:54.849 INFO kyuubi.SQLOperationListener: Query [3ac86686-f502-4f2d-9a98-d763e5b9548c]: Job 3 succeeded, 0 active jobs running
2021-05-08 10:25:54.857 INFO codegen.CodeGenerator: Code generated in 7.116325 ms
2021-05-08 10:25:54.858 INFO operation.ExecuteStatement: Processing kentyao's query[3ac86686-f502-4f2d-9a98-d763e5b9548c]: RUNNING_STATE -> FINISHED_STATE, statement: select /*+ REPARTITION(200) */ count(1) from (select  /*+ REPARTITION(300, a) */  a  from values(1),(1),(1),(2),(3) t(a)), time taken: 0.702 seconds
```