### PR TITLE
[KYUUBI #625]Kyuubi server-side support 'operation.idle. timeout'

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -17,7 +17,6 @@
 
 package org.apache.kyuubi.operation
 
-import java.time.Duration
 import java.util.concurrent.Future
 
 import org.apache.hive.service.rpc.thrift.{TProtocolVersion, TRowSet, TTableSchema}
@@ -35,8 +34,9 @@ abstract class AbstractOperation(opType: OperationType, session: Session)
   import OperationState._
 
   private final val handle = OperationHandle(opType, session.protocol)
-  private final val operationTimeout: Long = session.conf.get(OPERATION_IDLE_TIMEOUT.key)
-    .map(_.toLong).getOrElse(Duration.ofHours(3).toMillis)
+  private final val operationTimeout: Long = {
+    session.sessionManager.getConf.get(OPERATION_IDLE_TIMEOUT)
+  }
 
   protected final val statementId = handle.identifier.toString
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/session/SessionManagerSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/session/SessionManagerSuite.scala
@@ -32,14 +32,10 @@ class SessionManagerSuite extends FrontendServiceSuite with Eventually {
     .set(KyuubiConf.FRONTEND_BIND_PORT, 0)
     .set("kyuubi.test.server.should.fail", "false")
     .set(KyuubiConf.SESSION_CHECK_INTERVAL, Duration.ofSeconds(5).toMillis)
-    .set(KyuubiConf.SESSION_TIMEOUT, Duration.ofSeconds(5).toMillis)
+    .set(KyuubiConf.SESSION_IDLE_TIMEOUT, Duration.ofSeconds(5).toMillis)
+    .set(KyuubiConf.OPERATION_IDLE_TIMEOUT, Duration.ofSeconds(20).toMillis)
 
   test("close expired operations") {
-    sessionConf.put(
-      KyuubiConf.OPERATION_IDLE_TIMEOUT.key,
-      String.valueOf(Duration.ofSeconds(20).toMillis)
-    )
-
     withSessionHandle{ (client, handle) =>
       val req = new TCancelOperationReq()
       val req1 = new TGetSchemasReq(handle)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now we only get 'operation.idle.timeout' from user request. Kyuubi server-side should support "operation.idle. timeout".

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
