### PR TITLE
Capture exceptions in async ExecuteStatement

### DIFF
--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -91,8 +91,10 @@ class ExecuteStatement(
       isComplete = true
       remoteState match {
         case INITIALIZED_STATE | PENDING_STATE | RUNNING_STATE =>
-          isComplete = false
-          statusResp = client.GetOperationStatus(statusReq)
+          try {
+            statusResp = client.GetOperationStatus(statusReq)
+            isComplete = false
+          } catch onError(rethrow = false)
 
         case FINISHED_STATE =>
           setState(OperationState.FINISHED)

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -44,7 +44,8 @@ abstract class KyuubiOperation(
     ThriftUtils.verifyTStatus(tStatus)
   }
 
-  protected def onError(action: String = "operating"): PartialFunction[Throwable, Unit] = {
+  protected def onError(action: String = "operating",
+                        rethrow: Boolean = true): PartialFunction[Throwable, Unit] = {
     case e: Throwable =>
       state.synchronized {
         if (isTerminalState(state)) {
@@ -66,7 +67,9 @@ abstract class KyuubiOperation(
               KyuubiSQLException(s"Error $action $opType: ${e.getMessage}", e)
           }
           setOperationException(ke)
-          throw ke
+          if (rethrow) {
+            throw ke
+          }
         }
       }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When ExecuteStatement running in async, if engine broken(e.g. killed by yarn), the thread just crash without `setOperationException(ke)`, then client(like `beeline`) will hang.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

Manual tested on our yarn cluster: kill yarn app when executing statement.
1. `beeline` connect hiveserver2. Result: exit with error
2. `beeline` connect kyuubi(before this patch). Result: hang
3. `beeline` connect kyuubi(after this patch). Result:  exit with error
