### PR TITLE
Fix flaky test in ctl module

### DIFF
--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -203,12 +203,13 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedCreatedNodes))
       val znodeRoot = s"/$newNamespace"
-      val children = framework.getChildren.forPath(znodeRoot).asScala
+      val children = framework.getChildren.forPath(znodeRoot).asScala.sorted
       assert(children.size == 2)
-      assert(children.head ===
-        s"serviceUri=localhost:10000;version=$KYUUBI_VERSION;sequence=0000000000")
-      assert(children.last ===
-        s"serviceUri=localhost:10001;version=$KYUUBI_VERSION;sequence=0000000001")
+
+      assert(children.head.startsWith(
+        s"serviceUri=localhost:10000;version=$KYUUBI_VERSION;sequence="))
+      assert(children.last.startsWith(
+        s"serviceUri=localhost:10001;version=$KYUUBI_VERSION;sequence="))
       children.foreach { child =>
         framework.delete().forPath(s"""$znodeRoot/$child""")
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As `zookeeper` mentioned, the result of getChildren is no guarantee order.  So it is also no guarantee order that use exists children to create new node .

flaky test log:
```
- test expose zk service node to another namespace *** FAILED ***
  "...ceUri=localhost:1000[1];version=1.2.0;seque..." did not equal "...ceUri=localhost:1000[0];version=1.2.0;seque..." (ServiceControlCliSuite.scala:212)
  Analysis:
  "...ceUri=localhost:1000[1];version=1.2.0;seque..." -> "...ceUri=localhost:1000[0];version=1.2.0;seque..."
```


zookeeper description:
```
    /**
     * For the given znode path return the stat and children list.
     * <p>
     * If the watch is true and the call is successful (no exception is thrown),
     * a watch will be left on the node with the given path. The watch will be
     * triggered by a successful operation that deletes the node of the given
     * path or creates/delete a child under the node.
     * <p>
     * The list of children returned is not sorted and no guarantee is provided
     * as to its natural or lexical order.
     * <p>
     * A KeeperException with error code KeeperException.NoNode will be thrown
     * if no node with the given path exists.
     *
     * @since 3.3.0
     * 
     * @param path
     * @param watch
     * @param stat stat of the znode designated by path
     * @return an unordered array of children of the node with the given path
     * @throws InterruptedException If the server transaction is interrupted.
     * @throws KeeperException If the server signals an error with a non-zero
     *  error code.
     */
    public List<String> getChildren(String path, boolean watch, Stat stat)
            throws KeeperException, InterruptedException {
        return getChildren(path, watch ? watchManager.defaultWatcher : null,
                stat);
    }

```

### _How was this patch tested?_
Pass CI.