### PR TITLE
[KYUUBI #678]Fix: kyuubi ctl use default property if missing

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
@@ -63,11 +63,13 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
     // for create action, it only expose Kyuubi service instance to another domain,
     // so we do not use namespace from default conf
     if (action != ServiceControlAction.CREATE && namespace == null) {
-      Option(conf.get(HA_ZK_NAMESPACE)).foreach { v =>
+      namespace = conf.getOption(HA_ZK_NAMESPACE.key).getOrElse{
+        val defaultNamespace = conf.get(HA_ZK_NAMESPACE)
         if (verbose) {
-          info(s"Zookeeper namespace is not specified, use value from default conf:$v")
+          info(s"Zookeeper namespace is not specified," +
+            s" use value from default conf:$defaultNamespace")
         }
-        namespace = v
+        defaultNamespace
       }
     }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
@@ -63,7 +63,7 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
     // for create action, it only expose Kyuubi service instance to another domain,
     // so we do not use namespace from default conf
     if (action != ServiceControlAction.CREATE && namespace == null) {
-      conf.getOption(HA_ZK_NAMESPACE.key).foreach { v =>
+      Option(conf.get(HA_ZK_NAMESPACE)).foreach { v =>
         if (verbose) {
           info(s"Zookeeper namespace is not specified, use value from default conf:$v")
         }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
@@ -63,13 +63,10 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
     // for create action, it only expose Kyuubi service instance to another domain,
     // so we do not use namespace from default conf
     if (action != ServiceControlAction.CREATE && namespace == null) {
-      namespace = conf.getOption(HA_ZK_NAMESPACE.key).getOrElse{
-        val defaultNamespace = conf.get(HA_ZK_NAMESPACE)
-        if (verbose) {
-          info(s"Zookeeper namespace is not specified," +
-            s" use value from default conf:$defaultNamespace")
-        }
-        defaultNamespace
+      namespace = conf.get(HA_ZK_NAMESPACE)
+      if (verbose) {
+        info(s"Zookeeper namespace is not specified," +
+          s" use value from default conf:$namespace")
       }
     }
 

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
@@ -285,4 +285,14 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
       testPrematureExit(args4, "Only support expose Kyuubi server instance to another domain")
     }
   }
+
+  test("test use default property value if missing") {
+    val args = Array(
+      "list",
+      "--zk-quorum", zkQuorum
+    )
+    val opArgs = new ServiceControlCliArguments(args)
+    assert(opArgs.namespace == namespace)
+    assert(opArgs.version == KYUUBI_VERSION)
+  }
 }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
@@ -145,16 +145,10 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
 
     val args2 = Array(
       "list",
-      "--zk-quorum", zkQuorum
-    )
-    testPrematureExit(args2, "Zookeeper namespace is not specified")
-
-    val args3 = Array(
-      "list",
       "--zk-quorum", zkQuorum,
       "--namespace", namespace
     )
-    val opArgs = new ServiceControlCliArguments(args3)
+    val opArgs = new ServiceControlCliArguments(args2)
     assert(opArgs.action == ServiceControlAction.LIST)
   }
 
@@ -167,42 +161,36 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
 
       val args2 = Array(
         op,
-        "--zk-quorum", zkQuorum
-      )
-      testPrematureExit(args2, "Zookeeper namespace is not specified")
-
-      val args3 = Array(
-        op,
         "--zk-quorum", zkQuorum,
         "--namespace", namespace
       )
-      testPrematureExit(args3, "Must specify host")
+      testPrematureExit(args2, "Must specify host")
 
-      val args4 = Array(
+      val args3 = Array(
         op,
         "--zk-quorum", zkQuorum,
         "--namespace", namespace,
         "--host", host
       )
-      testPrematureExit(args4, "Must specify port")
+      testPrematureExit(args3, "Must specify port")
 
-      val args5 = Array(
+      val args4 = Array(
         op, "engine",
         "--zk-quorum", zkQuorum,
         "--namespace", namespace,
         "--host", host,
         "--port", port
       )
-      testPrematureExit(args5, "Must specify user name for engine")
+      testPrematureExit(args4, "Must specify user name for engine")
 
-      val args6 = Array(
+      val args5 = Array(
         op, "server",
         "--zk-quorum", zkQuorum,
         "--namespace", namespace,
         "--host", host,
         "--port", port
       )
-      val opArgs6 = new ServiceControlCliArguments(args6)
+      val opArgs6 = new ServiceControlCliArguments(args5)
       assert(opArgs6.action.toString.equalsIgnoreCase(op))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
when use `bin/kyuubi-ctl list` throw:
```
Exception in thread "main" org.apache.kyuubi.KyuubiException: Zookeeper namespace is not specified and no default value to load
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.fail(ServiceControlCliArguments.scala:339)
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.validateZkArguments(ServiceControlCliArguments.scala:136)
```
we expect: list engine nodes with default namespace `kyuubi`
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
