### PR TITLE
[TPCDS] kyuubi-tpcds should respect dsgen charset

### DIFF
--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
@@ -22,7 +22,7 @@ import java.lang.ProcessBuilder.Redirect
 import java.nio.file.{Files, Paths}
 import java.nio.file.attribute.PosixFilePermissions._
 
-import scala.io.BufferedSource
+import scala.io.{BufferedSource, Codec}
 
 import org.apache.spark.{KyuubiSparkUtils, SparkEnv}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -97,10 +97,12 @@ case class TableGenerator(
       val process = builder.start()
       val res = process.waitFor()
 
-      logger.info(s"Finish w/ $res ${cmd}")
+      logger.info(s"Finish w/ $res $cmd")
       val data = Paths.get(tempDir.toString, s"${name}_${i}_$parallelism.dat")
       val iterator = if (Files.exists(data)) {
-        new BufferedSource(new FileInputStream(data.toFile), 8192).getLines()
+        // ... realized that when opening the dat files I should use the “Cp1252” encoding.
+        // https://github.com/databricks/spark-sql-perf/pull/104
+        new BufferedSource(new FileInputStream(data.toFile), 8192)(Codec("cp1252")).getLines()
       } else {
         logger.warn(s"No data generated in child $i")
         Nil

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/TableGenerator.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.tpcds
 
-import java.io.{FileInputStream, InputStream}
+import java.io.InputStream
 import java.lang.ProcessBuilder.Redirect
 import java.nio.file.{Files, Paths}
 import java.nio.file.attribute.PosixFilePermissions._
 
-import scala.io.{BufferedSource, Codec}
+import scala.io.Source
 
 import org.apache.spark.{KyuubiSparkUtils, SparkEnv}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -102,7 +102,8 @@ case class TableGenerator(
       val iterator = if (Files.exists(data)) {
         // ... realized that when opening the dat files I should use the “Cp1252” encoding.
         // https://github.com/databricks/spark-sql-perf/pull/104
-        new BufferedSource(new FileInputStream(data.toFile), 8192)(Codec("cp1252")).getLines()
+        // noinspection SourceNotClosed
+        Source.fromFile(data.toFile, "cp1252", 8192).getLines
       } else {
         logger.warn(s"No data generated in child $i")
         Nil


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #713.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

run `/opt/spark3/bin/spark-submit --conf spark.sql.tpcds.scale.factor=10 --conf spark.sql.tpcds.database=tpcds_sf10 --class org.apache.kyuubi.tpcds.DataGenerator kyuubi-tpcds-*.jar`

before:
![image](https://user-images.githubusercontent.com/26535726/123400190-12344600-d5d8-11eb-9b68-e494adf67257.png)


after:
![image](https://user-images.githubusercontent.com/26535726/123400231-1d877180-d5d8-11eb-92d7-ce46d0bcc8c6.png)


- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
