### PR TITLE
[KYUUBI #732] Fix always print the name of abstract ServiceDiscovery class

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
@@ -30,7 +30,7 @@ import org.apache.kyuubi.service.Serverable
  */
 class EngineServiceDiscovery private(
     name: String,
-    server: Serverable) extends ServiceDiscovery(server) {
+    server: Serverable) extends ServiceDiscovery(name, server) {
   def this(server: Serverable) =
     this(classOf[EngineServiceDiscovery].getSimpleName, server)
 

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.service.Serverable
  */
 class KyuubiServiceDiscovery private(
     name: String,
-    server: Serverable) extends ServiceDiscovery(server) {
+    server: Serverable) extends ServiceDiscovery(name, server) {
   def this(server: Serverable) =
     this(classOf[KyuubiServiceDiscovery].getSimpleName, server)
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -49,7 +49,7 @@ import org.apache.kyuubi.util.{KyuubiHadoopUtils, ThreadUtils}
  * @param name   the name of the service itself
  * @param server the instance uri a service that used to publish itself
  */
-abstract class ServiceDiscovery private(
+abstract class ServiceDiscovery (
     name: String,
     server: Serverable) extends AbstractService(name) {
 

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -55,9 +55,6 @@ abstract class ServiceDiscovery (
 
   import ServiceDiscovery._
 
-  def this(server: Serverable) =
-    this(classOf[ServiceDiscovery].getSimpleName, server)
-
   private var _zkClient: CuratorFramework = _
   private var _serviceNode: PersistentNode = _
   /**


### PR DESCRIPTION

### _Why are the changes needed?_

The abstract `ServiceDiscovery` class has two subclass (KyuubiServiceDiscovery and EngineServiceDiscovery), but only abstract class name is always printed in the log.

```
2021-07-01 00:47:30.046 INFO kyuubi.SparkSQLEngineListener: Received ApplicationEnd Message from Spark at INITIALIZED, stopping
2021-07-01 00:47:30.047 INFO spark.SparkSQLEngine: Service: [ServiceDiscovery] is stopping.
2021-07-01 00:47:30.051 INFO imps.CuratorFrameworkImpl: backgroundOperationsLoop exiting
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

```
2021-07-01 01:53:09.124 INFO zookeeper.ClientCnxn: Socket error occurred: localhost/127.0.0.1:2181: Connection refused
2021-07-01 01:53:09.128 INFO client.EngineServiceDiscovery: Service[EngineServiceDiscovery] is initialized.
2021-07-01 01:53:09.128 INFO spark.SparkSQLEngine: Service[SparkSQLEngine] is initialized.

2021-07-01 01:54:13.417 INFO kyuubi.SparkSQLEngineListener: Received ApplicationEnd Message from Spark at INITIALIZED, stopping
2021-07-01 01:54:13.418 INFO spark.SparkSQLEngine: Service: [EngineServiceDiscovery] is stopping.
2021-07-01 01:54:13.420 INFO imps.CuratorFrameworkImpl: backgroundOperationsLoop exiting
```