### PR TITLE
Add Customized Configuration Item: kyuubi.statement.id

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -122,16 +122,17 @@ class ExecuteStatement(
   private def withLocalProperties[T](f: => T): T = {
     try {
       spark.sparkContext.setJobGroup(statementId, statement, forceCancel)
-      spark.sparkContext.setLocalProperty("kyuubi.statement.id", statementId)
+      spark.sparkContext.setLocalProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY, statementId)
       schedulerPool match {
         case Some(pool) =>
-          spark.sparkContext.setLocalProperty("spark.scheduler.pool", pool)
+          spark.sparkContext.setLocalProperty(ExecutionStatement.SPARK_SCHEDULER_POOL_KEY, pool)
         case None =>
       }
 
       f
     } finally {
-      spark.sparkContext.setLocalProperty("spark.scheduler.pool", null)
+      spark.sparkContext.setLocalProperty(ExecutionStatement.SPARK_SCHEDULER_POOL_KEY, null)
+      spark.sparkContext.setLocalProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY, null)
       spark.sparkContext.clearJobGroup()
     }
   }
@@ -153,4 +154,10 @@ class ExecuteStatement(
     spark.sparkContext.removeSparkListener(operationListener)
     super.cleanup(targetState)
   }
+}
+
+object ExecutionStatement {
+  final val KYUUBI_STATEMENT_ID_KEY = "kyuubi.statement.id"
+  final val SPARK_SCHEDULER_POOL_KEY = "spark.scheduler.pool"
+  final val SPARK_SQL_EXECUTION_ID_KEY = "spark.sql.execution.id"
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -40,6 +40,8 @@ class ExecuteStatement(
     queryTimeout: Long)
   extends SparkOperation(spark, OperationType.EXECUTE_STATEMENT, session) with Logging {
 
+  import ExecuteStatement._
+
   private val forceCancel =
     session.sessionManager.getConf.get(KyuubiConf.OPERATION_FORCE_CANCEL)
 
@@ -122,17 +124,17 @@ class ExecuteStatement(
   private def withLocalProperties[T](f: => T): T = {
     try {
       spark.sparkContext.setJobGroup(statementId, statement, forceCancel)
-      spark.sparkContext.setLocalProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY, statementId)
+      spark.sparkContext.setLocalProperty(KYUUBI_STATEMENT_ID_KEY, statementId)
       schedulerPool match {
         case Some(pool) =>
-          spark.sparkContext.setLocalProperty(ExecutionStatement.SPARK_SCHEDULER_POOL_KEY, pool)
+          spark.sparkContext.setLocalProperty(SPARK_SCHEDULER_POOL_KEY, pool)
         case None =>
       }
 
       f
     } finally {
-      spark.sparkContext.setLocalProperty(ExecutionStatement.SPARK_SCHEDULER_POOL_KEY, null)
-      spark.sparkContext.setLocalProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY, null)
+      spark.sparkContext.setLocalProperty(SPARK_SCHEDULER_POOL_KEY, null)
+      spark.sparkContext.setLocalProperty(KYUUBI_STATEMENT_ID_KEY, null)
       spark.sparkContext.clearJobGroup()
     }
   }
@@ -156,7 +158,7 @@ class ExecuteStatement(
   }
 }
 
-object ExecutionStatement {
+object ExecuteStatement {
   final val KYUUBI_STATEMENT_ID_KEY = "kyuubi.statement.id"
   final val SPARK_SCHEDULER_POOL_KEY = "spark.scheduler.pool"
   final val SPARK_SQL_EXECUTION_ID_KEY = "spark.sql.execution.id"

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -122,6 +122,7 @@ class ExecuteStatement(
   private def withLocalProperties[T](f: => T): T = {
     try {
       spark.sparkContext.setJobGroup(statementId, statement, forceCancel)
+      spark.sparkContext.setLocalProperty("kyuubi.statement.id", statementId)
       schedulerPool match {
         case Some(pool) =>
           spark.sparkContext.setLocalProperty("spark.scheduler.pool", pool)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -21,9 +21,9 @@ import java.util.Properties
 
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd}
-
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.apache.kyuubi.Logging
+import org.apache.kyuubi.engine.spark.operation.ExecutionStatement
 import org.apache.kyuubi.operation.Operation
 import org.apache.kyuubi.operation.log.OperationLog
 
@@ -46,7 +46,8 @@ class SQLOperationListener(
   // TODO: Fix this until the below ticket resolved
   // https://issues.apache.org/jira/browse/SPARK-34064
   private def sameGroupId(properties: Properties): Boolean = {
-    properties != null && properties.getProperty("kyuubi.statement.id") == operationId
+    properties != null &&
+      properties.getProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY) == operationId
   }
 
   private def withOperationLog(f : => Unit): Unit = {
@@ -63,7 +64,8 @@ class SQLOperationListener(
       val jobId = jobStart.jobId
       val stageSize = jobStart.stageInfos.size
       if (executionId.isEmpty) {
-        executionId = Option(jobStart.properties.getProperty("spark.sql.execution.id"))
+        executionId = Option(
+          jobStart.properties.getProperty(ExecutionStatement.SPARK_SQL_EXECUTION_ID_KEY))
           .map(_.toLong)
       }
       withOperationLog {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 
 import org.apache.kyuubi.Logging
-import org.apache.kyuubi.engine.spark.operation.ExecutionStatement
+import org.apache.kyuubi.engine.spark.operation.ExecuteStatement._
 import org.apache.kyuubi.operation.Operation
 import org.apache.kyuubi.operation.log.OperationLog
 
@@ -48,7 +48,7 @@ class SQLOperationListener(
   // https://issues.apache.org/jira/browse/SPARK-34064
   private def sameGroupId(properties: Properties): Boolean = {
     properties != null &&
-      properties.getProperty(ExecutionStatement.KYUUBI_STATEMENT_ID_KEY) == operationId
+      properties.getProperty(KYUUBI_STATEMENT_ID_KEY) == operationId
   }
 
   private def withOperationLog(f : => Unit): Unit = {
@@ -66,7 +66,7 @@ class SQLOperationListener(
       val stageSize = jobStart.stageInfos.size
       if (executionId.isEmpty) {
         executionId = Option(
-          jobStart.properties.getProperty(ExecutionStatement.SPARK_SQL_EXECUTION_ID_KEY))
+          jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
           .map(_.toLong)
       }
       withOperationLog {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -47,8 +47,7 @@ class SQLOperationListener(
   // TODO: Fix this until the below ticket resolved
   // https://issues.apache.org/jira/browse/SPARK-34064
   private def sameGroupId(properties: Properties): Boolean = {
-    properties != null &&
-      properties.getProperty(KYUUBI_STATEMENT_ID_KEY) == operationId
+    properties != null && properties.getProperty(KYUUBI_STATEMENT_ID_KEY) == operationId
   }
 
   private def withOperationLog(f : => Unit): Unit = {
@@ -65,8 +64,7 @@ class SQLOperationListener(
       val jobId = jobStart.jobId
       val stageSize = jobStart.stageInfos.size
       if (executionId.isEmpty) {
-        executionId = Option(
-          jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
+        executionId = Option(jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
           .map(_.toLong)
       }
       withOperationLog {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -19,7 +19,6 @@ package org.apache.spark.kyuubi
 
 import java.util.Properties
 
-import org.apache.spark.SparkContext.SPARK_JOB_GROUP_ID
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd}
@@ -47,7 +46,7 @@ class SQLOperationListener(
   // TODO: Fix this until the below ticket resolved
   // https://issues.apache.org/jira/browse/SPARK-34064
   private def sameGroupId(properties: Properties): Boolean = {
-    properties != null && properties.getProperty(SPARK_JOB_GROUP_ID) == operationId
+    properties != null && properties.getProperty("kyuubi.statement.id") == operationId
   }
 
   private def withOperationLog(f : => Unit): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -22,6 +22,7 @@ import java.util.Properties
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.engine.spark.operation.ExecutionStatement
 import org.apache.kyuubi.operation.Operation


### PR DESCRIPTION
For broadcast, Spark will introduce a new runId as SPARK_JOB_GROUP_ID. That cause we can't follow up this statement's whole life by SPARK_JOB_GROUP_ID.
This configuration item will be set when this statement was submitted and it will not be changed.
You can get the dependency relationship from job or stage to statement by this configuration item in this statement's whole life.
