### PR TITLE
Add kyuubi-spark-monitor module in nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         profiles:
-          - '-Pspark-master -pl :kyuubi-spark-sql-engine,:kyuubi-common,:kyuubi-ha,:kyuubi-zookeeper'
+          - '-Pspark-master -pl :kyuubi-spark-sql-engine,:kyuubi-common,:kyuubi-ha,:kyuubi-zookeeper,:kyuubi-spark-monitor'
     env:
       SPARK_LOCAL_IP: localhost
     steps:


### PR DESCRIPTION
Description:
Error:  Failed to execute goal on project kyuubi-spark-sql-engine: Could not resolve dependencies for project org.apache.kyuubi:kyuubi-spark-sql-engine:jar:1.3.0-SNAPSHOT: Could not find artifact org.apache.kyuubi:kyuubi-spark-monitor:jar:1.3.0-SNAPSHOT in Apache Snapshots Repository (https://repository.apache.org/snapshots/) -> [Help 1]

Add Kyuubi-spark-monitor module in nightly.yml